### PR TITLE
Fix "multiple tabs are used for indentation"

### DIFF
--- a/plugin/beautifier.vim
+++ b/plugin/beautifier.vim
@@ -332,6 +332,8 @@ func! BeautifierEditorconfigHook(config)
       let config["indent_char"] = ' '
     elseif config["indent_style"] == 'tab'
       let config["indent_char"] = '\t'
+      " When the indent_char is tab, we always want to use 1 tab
+      let config["indent_size"] = 1
     endif
   endif
 


### PR DESCRIPTION
The plugin didn't work as I expected:
I would like to have tabstop=softtabstop=shiftwidth=4 and run this plugin to format my JavaScript file. The .editorconfig settings to achieve that should be:

[**.js]
indent_style = tab
tab_width=4
indent_size = tab
However in this case the plugin uses 4 tabs for every level of indentation. I expect it to use only 1.
With this .editorconfig:

[**.js]
indent_style = tab
tab_width=4
indent_size = 1
It works properly, uses only 1 tab for indentation and sets tabstop=4, however in this case shiftwidth and softtabstop are both set to 1.

This code change fixes this: whenever the indent_style is 'tab', it always uses 1 tab for indentation.
Fixes issue #11 
