### PR TITLE
Add range beautify functions

### DIFF
--- a/plugin/beautifier.vim
+++ b/plugin/beautifier.vim
@@ -401,7 +401,8 @@ func! Beautifier(...)
 
   let lines_Beautify = split(result, "\n")
 
-  call setline(line1, lines_Beautify)
+  silent exec line1.",".line2."d"
+  call append(line1 - 1, lines_Beautify)
 
   " delete excess lines
   if lines_length > len(lines_Beautify)
@@ -459,12 +460,24 @@ endfun
 
 " @param {[Number|String]} a:0 Default value '1'
 " @param {[Number|String]} a:1 Default value '$'
+fun! RangeJsBeautify() range
+  return call('Beautifier', extend(['js'], [a:firstline, a:lastline]))
+endfun
+
 fun! JsBeautify(...)
   return call('Beautifier', extend(['js'], a:000))
 endfun
 
+fun! RangeHtmlBeautify() range
+  return call('Beautifier', extend(['html'], [a:firstline, a:lastline]))
+endfun
+
 fun! HtmlBeautify(...)
   return call('Beautifier', extend(['html'], a:000))
+endfun
+
+fun! RangeCSSBeautify() range
+  return call('Beautifier', extend(['css'], [a:firstline, a:lastline]))
 endfun
 
 fun! CSSBeautify(...)


### PR DESCRIPTION
The use case is that I typically don't want to beautify a whole file, but just a little bit of code I've selected.
Range*Beautify allows you to do a visual selection and beautify just that.
Also using delete / append s.t. it doesn't overwrite lines below if the beautified code takes more lines.

Note: This is my first foray into vimscript, feel free to rip apart, make more idiomatic, etc

Start:

```
var blah = 'hi';
var b = {does: 'it', work: 'huh?'};

var c = {does: 'it', work: 'huh?'};

var d = {does: 'it', work: 'huh?'};
```

Visual select lines `var b...` and `var c...` and then beautify with range beautifier.

End:

```
var blah = 'hi';
var b = {
  does: 'it',
  work: 'huh?'
};

var c = {
  does: 'it',
  work: 'huh?'
};

var d = {does: 'it', work: 'huh?'};
```
