### PR TITLE
Node may be called nodejs in some platform. Fixed

### DIFF
--- a/plugin/beautifier.vim
+++ b/plugin/beautifier.vim
@@ -378,8 +378,12 @@ func! Beautifier(...)
   let path = fnameescape(path)
   " Get external engine which will
   " be execute javascript file
-  " by default get node
-  let engine = get(opts, 'bin', 'node')
+  " by default get nodejs
+  let engine = get(opts, 'bin', 'nodejs')
+  " nodejs may be called node
+  if !executable(engine)
+      let engine = get(opts, 'bin', 'node')
+  endif
 
   " Get content from the files
   let content = getline(line1, line2)


### PR DESCRIPTION
Not perfect, but it's okay. The only problem is when you just have node(not nodejs), it has no effect without any error msg. See issue #58.
