### PR TITLE
Fix finding .editorconfig in Windows vimfiles dir

### DIFF
--- a/plugin/beautifier.vim
+++ b/plugin/beautifier.vim
@@ -32,7 +32,11 @@ let s:supportedFileTypes = ['js', 'css', 'html', 'jsx', 'json']
 
 "% Helper functions and variables
 let s:plugin_Root_directory = fnamemodify(expand("<sfile>"), ":h")
-let s:paths_Editorconfig = map(['$HOME/.editorconfig', '$HOME/.vim/.editorconfig', '$HOME/.config/nvim/.editorconfig', s:plugin_Root_directory.'/.editorconfig'], 'expand(v:val)')
+let s:paths_Editorconfig = map(['$HOME/.editorconfig',
+  \ '$HOME/.vim/.editorconfig',
+  \ '$HOME/vimfiles/.editorconfig',
+  \ '$HOME/.config/nvim/.editorconfig',
+  \ s:plugin_Root_directory.'/.editorconfig'], 'expand(v:val)')
 
 " Function for debugging
 " @param {Any} content Any type which will be converted


### PR DESCRIPTION
On Windows, the default path for .vim directory is $HOME/vimfiles.
This commit adds that path to the list to search when looking for .editorconfig files.
Fixes #101